### PR TITLE
enh(options): except to specify protocols to keep

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,9 +1,13 @@
 /**
  * Only keep links with the given protocols.
  *
+ * @param {object} options Options
+ * @param {string[]} options.except - Protocols to exclude. Defauls to `['http', 'https']`.
  * @returns
  *   Transform.
  */
-export default function remarkUnlink(): (tree: Root) => undefined;
+export default function remarkUnlinkProtocols(options?: {
+    except: string[];
+}): (tree: Root) => undefined;
 export type PhrasingContent = import("mdast").PhrasingContent;
 export type Root = import("mdast").Root;

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,15 +6,17 @@
 import {squeezeParagraphs} from 'mdast-squeeze-paragraphs'
 import {visit} from 'unist-util-visit'
 
-const protocols = ['http', 'https']
-
 /**
  * Only keep links with the given protocols.
  *
+ * @param {object} options Options
+ * @param {string[]} options.except - Protocols to exclude. Defauls to `['http', 'https']`.
  * @returns
  *   Transform.
  */
-export default function remarkUnlink() {
+export default function remarkUnlinkProtocols(
+  options = {except: ['http', 'https']}
+) {
   /**
    * Transform.
    *
@@ -35,7 +37,7 @@ export default function remarkUnlink() {
         if (
           url &&
           url.includes(':') &&
-          !protocols.some((p) => url.startsWith(`${p}:`))
+          !options.except.some((proto) => url.startsWith(`${proto}:`))
         ) {
           parent.children.splice(index, 1)
           return index
@@ -54,7 +56,7 @@ export default function remarkUnlink() {
         if (
           url &&
           url.includes(':') &&
-          !protocols.some((p) => url.startsWith(`${p}:`))
+          !options.except.some((proto) => url.startsWith(`${proto}:`))
         ) {
           parent.children.splice(index, 1, ...node.children)
           return index

--- a/test/fixtures/options/input.md
+++ b/test/fixtures/options/input.md
@@ -1,0 +1,35 @@
+## TOC
+
+Parsed with option `{ except: ["other"] }`.
+So only keeping the `other:...` links.
+
+- [section 1](#section-1)
+- [section 2](#section-2)
+
+## https is stripped
+
+Section [content][1] may include some [links](https://domain.name/path).
+
+[1]: https://domain.name/path
+
+## http is stripped
+
+Section [content][2] may include some [links](http://domain.name/path).
+
+[2]: http://domain.name/path
+
+## images
+
+![some images are here also](https://gif.com/1.gif)
+
+More content.
+
+## other protocols
+
+Section [content][3] may include some [links](test://domain.name/path).
+
+## empty other protocol
+
+[](other://test.me)
+
+[3]: other://domain.name/path

--- a/test/fixtures/options/options.json
+++ b/test/fixtures/options/options.json
@@ -1,0 +1,1 @@
+{"except": ["other"]}

--- a/test/fixtures/options/output.md
+++ b/test/fixtures/options/output.md
@@ -1,0 +1,31 @@
+## TOC
+
+Parsed with option `{ except: ["other"] }`.
+So only keeping the `other:...` links.
+
+* [section 1](#section-1)
+* [section 2](#section-2)
+
+## https is stripped
+
+Section content may include some links.
+
+## http is stripped
+
+Section content may include some links.
+
+## images
+
+![some images are here also](https://gif.com/1.gif)
+
+More content.
+
+## other protocols
+
+Section [content][3] may include some links.
+
+## empty other protocol
+
+[](other://test.me)
+
+[3]: other://domain.name/path

--- a/test/index.js
+++ b/test/index.js
@@ -3,9 +3,9 @@ import fs from 'node:fs/promises'
 import process from 'node:process'
 import test from 'node:test'
 import {remark} from 'remark'
-import remarkUnlink from 'remark-unlink-protocols'
+import remarkUnlinkProtocols from 'remark-unlink-protocols'
 
-test('remarkUnlink', async function (t) {
+test('remarkUnlinkProtocols', async function (t) {
   await t.test('should expose the public api', async function () {
     assert.deepEqual(
       Object.keys(await import('remark-unlink-protocols')).sort(),
@@ -31,11 +31,13 @@ test('fixtures', async function (t) {
       const outputUrl = new URL('output.md', folderUrl)
 
       const input = String(await fs.readFile(inputUrl))
+      /** @type {{ except: string[] } | undefined} */
+      const options = await readOptions(new URL('options.json', folderUrl))
 
       /** @type {string} */
       let output
 
-      const process_ = remark().use(remarkUnlink)
+      const process_ = remark().use(remarkUnlinkProtocols, options)
 
       const actual = String(await process_.process(input))
 
@@ -54,3 +56,18 @@ test('fixtures', async function (t) {
     })
   }
 })
+
+/**
+ * @param {import("fs").PathLike | fs.FileHandle} optionsUrl
+ * @returns {Promise<{except: string[]} | undefined>}
+ */
+async function readOptions(optionsUrl) {
+  /** @type { Buffer } */
+  let data
+  try {
+    data = await fs.readFile(optionsUrl)
+  } catch {
+    return undefined
+  }
+  return JSON.parse(String(data))
+}


### PR DESCRIPTION
Usage:
```js
remark().use(remarkUnlinkProtocols,
  { except: ["http", "https", "mailto"] }
)
```
