### PR TITLE
chore(package): adjust repository setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "text",
     "unified"
   ],
-  "repository": "nextcloud-libraries/remark-unlink-protocols",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nextcloud-libraries/remark-unlink-protocols.git"
+  },
   "bugs": "https://github.com/nextcloud-libraries/remark-unlink-protocols/issues",
   "author": "Max <max@nextcloud.com>",
   "contributors": [],


### PR DESCRIPTION
npm publish was warning:

```
npm warn publish errors corrected:
npm warn publish "repository" was changed from a string to an object
npm warn publish "repository.url" was normalized to "git+https://github.com/nextcloud-libraries/remark-unlink-protocols.git"
```

https://github.com/nextcloud-libraries/remark-unlink-protocols/actions/runs/15250834484/job/42887207437
