### PR TITLE
ci: update npm-publish.yml workflow from template

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,16 +13,14 @@ on:
     types: [published]
 
 permissions:
+  id-token: write  # Required for OIDC
   contents: read
-  packages: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-
     name: Build and publish to npm
-    env:
-      RELEASE_GROUP: ${{ (contains(github.ref, 'rc') || contains(github.ref, 'beta') || contains(github.ref, 'alpha')) && 'next' || 'latest' }}
+    environment: npm-publish
 
     steps:
       - name: Checkout
@@ -30,21 +28,53 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Read package.json
+        uses: nextcloud-libraries/parse-package-engines-action@122ae05d4257008180a514e1ddeb0c1b9d094bdd # v0.1.0
+        id: versions
+
       - name: Set up node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version-file: 'package.json'
+          node-version: ${{ steps.versions.outputs.node-version }}
+          registry-url: https://registry.npmjs.org
+
+      - name: Set up npm
+        run: npm i -g 'npm@${{ steps.versions.outputs.package-manager-version }}'
+
+      - name: Check tag matches package.json
+        run: |
+          VERSION=$(node -p -e "require('./package.json').version")
+          GH_VERSION=$(echo "$GH_VERSION" | sed s,\^v,,)
+          if [ "$VERSION" != "$GH_VERSION" ]; then
+            echo "$VERSION does not match $GH_VERSION"
+            exit 1;
+          fi;
+        env:
+          GH_VERSION: ${{ github.event.release.tag_name }}
 
       - name: Install dependencies & build
         env:
           CYPRESS_INSTALL_BINARY: 0
         run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run build --if-present
+
+      - name: Fetch latest tag
+        id: latest-tag
+        run: |
+          TAG=$(gh release list \
+            --exclude-drafts \
+            --exclude-pre-releases \
+            --json isLatest,tagName \
+            --jq 'map(select(.isLatest == true))[].tagName' \
+            -R ${{ github.repository }})
+          echo "Latest tag is $TAG"
+          echo "LATEST_TAG=$TAG" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Publish
         run: |
-          npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN
           npm publish --tag $RELEASE_GROUP
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_GROUP: ${{ (contains(github.ref, 'rc') || contains(github.ref, 'beta') || contains(github.ref, 'alpha')) && 'next' || ((steps.latest-tag.outputs.LATEST_TAG != github.event.release.tag_name) && 'stable' || 'latest') }}


### PR DESCRIPTION
Automated update of the npm-publish.yml workflow from https://github.com/nextcloud-libraries/.github triggered by susnux